### PR TITLE
feat: Table Generator Support Cases

### DIFF
--- a/.github/workflows/markdown-table-workflow/index.js
+++ b/.github/workflows/markdown-table-workflow/index.js
@@ -20,7 +20,7 @@ const verboseTemplates = {
   "Analyze With Perspectiveapi": "Analyze With PerspectiveAPI",
   "Generate Pdf": "Generate PDF",
   "Prompt Chatgpt": "Prompt ChatGPT",
-  "Push Notifications With Fcm": "Push Notifications With FCM",
+  "Push Notification With Fcm": "Push Notifications With FCM",
   "Url Shortener": "URL Shortener",
   "Whatsapp With Vonage": "WhatsApp With Vonage",
 };

--- a/.github/workflows/markdown-table-workflow/index.js
+++ b/.github/workflows/markdown-table-workflow/index.js
@@ -16,49 +16,93 @@ const verboseRuntimes = {
   swift: "Swift",
 };
 
+const verboseTemplates = {
+  "Analyze With Perspectiveapi": "Analyze With PerspectiveAPI",
+  "Generate Pdf": "Generate PDF",
+  "Prompt Chatgpt": "Prompt ChatGPT",
+  "Push Notifications With Fcm": "Push Notifications With FCM",
+  "Url Shortener": "URL Shortener",
+  "Whatsapp With Vonage": "WhatsApp With Vonage",
+};
+
+function toTitleCase(text) {
+  return text
+    .replace(/_/g, " ")
+    .replace(/-/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()));
+}
+
+function normalizeTemplate(template) {
+  const titleCase = toTitleCase(template);
+  return titleCase in verboseTemplates
+    ? verboseTemplates[titleCase]
+    : titleCase;
+}
+
 const folderDenylist = [".github", ".git"];
 
-const generateUniqueTemplates = (runtimes) => {
-  let templates = [];
+function getDirectories(dirPath) {
+  return fs
+    .readdirSync(dirPath, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
+    .filter((name) => !folderDenylist.includes(name));
+}
 
-  for (const runtime of runtimes) {
-    const folders = fs
-      .readdirSync(path.join(".", `../../../${runtime}`), {
-        withFileTypes: true,
-      })
-      .filter((dirent) => dirent.isDirectory())
-      .map((dirent) => dirent.name);
+const runtimeDirs = getDirectories(path.join(".", "../../../"));
+console.table(runtimeDirs);
 
-    templates.push(...folders);
-  }
+const runtimeToTemplate = {};
+for (const runtimeDir of runtimeDirs) {
+  const runtime = verboseRuntimes[runtimeDir] || runtimeDir;
 
-  return [...new Set(templates)];
-};
+  const templateDirs = getDirectories(path.join(".", "../../../", runtimeDir));
+  runtimeToTemplate[runtime] = [];
+  console.log(runtime, templateDirs);
 
-const generateTableRows = (templates, runtimes) => {
-  return templates.map((template) => {
-    const languagesSupport = runtimes.map((runtime) => {
-      return fs.existsSync(path.join(".", `../../../${runtime}/${template}`))
-        ? `[✅](/${runtime}/${template})`
-        : "🏗️";
+  for (const templateDir of templateDirs) {
+    const template = normalizeTemplate(templateDir);
+    runtimeToTemplate[runtime].push({
+      name: template,
+      dir: path.join(".", runtimeDir, templateDir),
     });
+  }
+}
 
-    return [template, ...languagesSupport];
+const templateToRuntimes = {};
+for (const runtime of Object.keys(runtimeToTemplate)) {
+  for (const template of runtimeToTemplate[runtime]) {
+    if (!(template.name in templateToRuntimes)) {
+      templateToRuntimes[template.name] = [];
+    }
+
+    templateToRuntimes[template.name].push({
+      name: runtime,
+      dir: template.dir,
+    });
+  }
+}
+
+const sortedRuntimes = Object.keys(runtimeToTemplate).sort((a, b) => {
+  return runtimeToTemplate[b].length - runtimeToTemplate[a].length;
+});
+
+const sortedTableRows = Object.keys(templateToRuntimes)
+  .sort((a, b) => {
+    return templateToRuntimes[b].length - templateToRuntimes[a].length;
+  })
+  .map((template) => {
+    return [
+      template,
+      ...sortedRuntimes.map((runtime) => {
+        const matchingRuntime = templateToRuntimes[template].find(
+          (r) => r.name === runtime
+        );
+        return matchingRuntime ? `[✅](${matchingRuntime.dir})` : "🏗️";
+      }),
+    ];
   });
-};
-
-const sortRuntimesBySupport = (runtimes, uniqueTemplates) => {
-  return runtimes.sort((a, b) => {
-    const aTemplates = uniqueTemplates.filter((template) =>
-      fs.existsSync(path.join(".", `../../../${a}/${template}`))
-    );
-    const bTemplates = uniqueTemplates.filter((template) =>
-      fs.existsSync(path.join(".", `../../../${b}/${template}`))
-    );
-
-    return bTemplates.length - aTemplates.length;
-  });
-};
 
 const updateReadmeFile = (readmePath, table) => {
   const readme = fs.readFileSync(readmePath).toString();
@@ -77,29 +121,8 @@ const updateReadmeFile = (readmePath, table) => {
   }
 };
 
-let runtimes = fs
-  .readdirSync(path.join(".", "../../../"), { withFileTypes: true })
-  .filter((dirent) => dirent.isDirectory())
-  .map((dirent) => dirent.name)
-  .filter((folder) => !folderDenylist.includes(folder))
-  .sort();
-
-const uniqueTemplates = generateUniqueTemplates(runtimes);
-runtimes = sortRuntimesBySupport(runtimes, uniqueTemplates);
-const tableRows = generateTableRows(uniqueTemplates, runtimes);
-
-const sortedTableRows = tableRows.sort((a, b) => {
-  const aCount = a.filter((column) => column !== "").length;
-  const bCount = b.filter((column) => column !== "").length;
-
-  return aCount > bCount ? -1 : 1;
-});
-
 const table = markdownTable([
-  [
-    "Template",
-    ...runtimes.map((r) => (verboseRuntimes[r] ? verboseRuntimes[r] : r)),
-  ],
+  ["Template", ...sortedRuntimes],
   ...sortedTableRows,
 ]);
 

--- a/.github/workflows/markdown-table-workflow/index.js
+++ b/.github/workflows/markdown-table-workflow/index.js
@@ -16,13 +16,41 @@ const verboseRuntimes = {
   swift: "Swift",
 };
 
-const verboseTemplates = {
-  "Analyze With Perspectiveapi": "Analyze With PerspectiveAPI",
-  "Generate Pdf": "Generate PDF",
-  "Prompt Chatgpt": "Prompt ChatGPT",
-  "Push Notification With Fcm": "Push Notifications With FCM",
-  "Url Shortener": "URL Shortener",
-  "Whatsapp With Vonage": "WhatsApp With Vonage",
+const overrideWords = {
+  a: "a",
+  an: "an",
+  and: "and",
+  as: "as",
+  at: "at",
+  but: "but",
+  by: "by",
+  for: "for",
+  if: "if",
+  in: "in",
+  nor: "nor",
+  of: "of",
+  on: "on",
+  or: "or",
+  so: "so",
+  the: "the",
+  to: "to",
+  up: "up",
+  with: "with",
+  yet: "yet",
+  is: "is",
+  are: "are",
+  was: "was",
+  were: "were",
+  has: "has",
+  have: "have",
+  been: "been",
+  am: "am",
+  perspectiveapi: "PerspectiveAPI",
+  pdf: "PDF",
+  chatgpt: "ChatGPT",
+  fcm: "FCM",
+  url: "URL",
+  whatsapp: "WhatsApp",
 };
 
 const folderDenylist = [".github", ".git"];
@@ -35,19 +63,21 @@ function getDirectories(dirPath) {
     .filter((name) => !folderDenylist.includes(name));
 }
 
-function toTitleCase(text) {
-  return text
-    .replace(/_/g, " ")
-    .replace(/-/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()));
-}
-
-function normalizeTemplate(template) {
-  const titleCase = toTitleCase(template);
-  return titleCase in verboseTemplates
-    ? verboseTemplates[titleCase]
-    : titleCase;
+function normalizeTemplateName(template) {
+  return template
+    .replace(/[_-]|([a-z])([A-Z])/g, (_, p1, p2) => (p1 ? `${p1} ${p2}` : " "))
+    .toLowerCase()
+    .split(" ")
+    .map((word, i, words) => {
+      const overrideWord = overrideWords[word];
+      if (!overrideWord) {
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      }
+      return i === 0 || i === words.length - 1
+        ? overrideWord.charAt(0).toUpperCase() + overrideWord.slice(1)
+        : overrideWord;
+    })
+    .join(" ");
 }
 
 function getRuntimeToTemplates() {
@@ -61,9 +91,9 @@ function getRuntimeToTemplates() {
     );
 
     runtimeToTemplates[runtime] = templateDirs.map((templateDir) => {
-      const template = normalizeTemplate(templateDir);
+      const name = normalizeTemplateName(templateDir);
       return {
-        name: template,
+        name: name,
         dir: path.join(".", runtimeDir, templateDir),
       };
     });


### PR DESCRIPTION
- Adds verbose aliases for Template Names
- Normalizes template names to 'Title Case' by default, and supports runtimes using kebab-case, snake_case, PascalCase and camelCase for their templates
- Orders templates by number of supported runtimes
- Orders runtimes by number of templates

<img width="859" alt="Screenshot 2023-08-03 at 10 14 38" src="https://github.com/appwrite/templates/assets/22452787/f224108d-c033-4c8f-a19c-f4ba4bc4b218">



