### PR TITLE
updated content-type in main function

### DIFF
--- a/python/prompt_chatgpt/src/main.py
+++ b/python/prompt_chatgpt/src/main.py
@@ -11,7 +11,7 @@ def main(context):
             get_static_file("index.html"),
             200,
             {
-                "Content-Type": "text/html; charset=utf-8",
+                "content-type": "text/html; charset=utf-8"
             },
         )
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

This PR is a bug fix for the issue #220, which resolves the issue of python chatgpt template not being rendered. 

## Test Plan
- The issue was the we were send Content-Type from backend in python from appwrite function. Which was not interpreated by browser correctly. 
- I verified the above problem by going to inspect elements in google chrome and checking the content-type was showing plain/text, which was creating problem of HTML page not being rendered.
- To fix the issue, I corrected the Content-Type changing the spelling to content-type, now the browser was able to detect the content-type correctly.
- I have tested this by creating a cloud instance of prompt chatgpt using appwrite cloud, and then changing code in my own instance.
- I have deployed 2 instance 
            - The original version with is - https://652040168d5644809a5a.appwrite.global/
            - The corrected version is - https://651f1233b7aa4fe187ae.appwrite.global/

## Related PRs and Issues

The related issue is #220 

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read the contributing guidelines on issues.