### PR TITLE
Added @types/bun dependency to bun starter template

### DIFF
--- a/bun/starter/package.json
+++ b/bun/starter/package.json
@@ -11,6 +11,7 @@
     "node-appwrite": "^9.0.0"
   },
   "devDependencies": {
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "@types/bun": "^1.1.16"
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR includes `@types/bun` in the `devDependencies` of the `package.json` of the `bun/starter` template to allow IDEs to resolve the TypeScript definitions for Bun.

## Test Plan

1. `cd` onto the `bun/starter` directory
2. Run `npm install` to install all the dependencies
3. Open `src/main.ts` and observe that Bun is not complaining

Note: If you have Bun globally installed, you won't see it. Please open the template in a sandbox environment to see the issue OR create a Bun 1.0 or Bun 1.1 starter function using Appwrite.

## Related PRs and Issues

Issue: #318

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes