### PR TITLE
fix: replace perplexity AI deprecated model

### DIFF
--- a/node/chat-with-perplexity-ai/src/main.js
+++ b/node/chat-with-perplexity-ai/src/main.js
@@ -28,7 +28,7 @@ export default async ({ req, res, error }) => {
 
   try {
     const response = await perplexity.chat.completions.create({
-      model: 'mistral-7b-instruct',
+      model: 'llama-3.1-sonar-small-128k-online',
       max_tokens: parseInt(process.env.PERPLEXITY_MAX_TOKENS ?? '512'),
       messages: [{ role: 'user', content: req.bodyJson.prompt }],
       stream: false,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?

Updates the Perplexity AI integration template to use the currently supported `llama-3.1-sonar-small-128k-online` model instead of the deprecated `mistral-7b-instruct` model. This change will restore the functionality of the Perplexity integration template.

## Test Plan

As this is a model update in the template, testing can be performed by:
- Reviewing the model name matches the officially supported models from Perplexity AI documentation
- Deploying the updated template in Appwrite Cloud to verify it initializes correctly
- Testing the deployed function with sample queries

Note: I've verified the model name against the official Perplexity AI documentation: https://docs.perplexity.ai/guides/model-cards

## Related PRs and Issues

- Fixes #325

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes, I have read and understood the contributing guidelines.