### PR TITLE
Fix InputFile imports in Hugging Face templates

### DIFF
--- a/node/music-generation-with-huggingface/src/appwrite.js
+++ b/node/music-generation-with-huggingface/src/appwrite.js
@@ -1,4 +1,5 @@
-import { Client, Databases, ID, InputFile, Storage } from 'node-appwrite';
+import { Client, Databases, ID, Storage } from 'node-appwrite';
+import { InputFile } from 'node-appwrite/file';
 
 class AppwriteService {
   constructor(apiKey) {

--- a/node/text-to-speech-with-huggingface/src/appwrite.js
+++ b/node/text-to-speech-with-huggingface/src/appwrite.js
@@ -1,4 +1,5 @@
-import { Client, Databases, ID, InputFile, Storage } from 'node-appwrite';
+import { Client, Databases, ID, Storage } from 'node-appwrite';
+import { InputFile } from 'node-appwrite/file';
 
 class AppwriteService {
   constructor(apiKey) {


### PR DESCRIPTION
Fixes the Node builds for the Text to speech and Music generation Hugging Face templates.

`InputFile` is exported through the `node-appwrite/file` subpath in node-appwrite 14.x, not from the package root. The 1.0.0 release therefore fails both templates during `npm run setup`.

Tested with a local Appwrite Docker Compose stack and Playwright-driven template deployments:

- Text to speech (`node-22`): ready
- Music generation (`node-22`): ready
- Prettier: passed
- Direct ESM imports with installed lockfile dependencies: passed

Related: appwrite/appwrite#13071
